### PR TITLE
Update schema-tools to v5.15.1

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-amsterdam-schema-tools==5.14.1
+amsterdam-schema-tools==5.15.1
 pika==1.3.1
 
 black~=23.1.0


### PR DESCRIPTION
Needs https://github.com/Amsterdam/schema-tools/pull/498 to be merged and released to PyPI