### PR TITLE
Log finishing a message with INFO level

### DIFF
--- a/src/gobeventconsumer/consumer.py
+++ b/src/gobeventconsumer/consumer.py
@@ -238,7 +238,7 @@ class GOBEventConsumer:
                     importer.process_event(header, data, recovery_mode=recovery_mode)
 
                 channel.basic_ack(delivery_tag=method.delivery_tag)
-            self._logger.debug("Finished message handling")
+            self._logger.info(f"Finished message for catalog {dataset_schema.id} with routing key {method.routing_key}")
 
         return handle_message
 

--- a/src/tests/test_consumer.py
+++ b/src/tests/test_consumer.py
@@ -172,6 +172,9 @@ class TestGOBEventConsumer(TestCase):
             },
             recovery_mode=method.redelivered
         )
+        gec._logger.info.assert_called_with(
+            f"Finished message for catalog gebieden with routing key gebieden.bouwblokken"
+        )
 
     @patch("gobeventconsumer.consumer.create_engine")
     @patch("gobeventconsumer.consumer.EventsProcessor")


### PR DESCRIPTION
Inform user when message handling is finished.
Indicates when `INFO:schematools.events.full:End of full load sequence. Replacing active table.` task is done