### PR TITLE
slim-bullseye with current Python 3.9.x.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM amsterdam/gob_wheelhouse:3.9-buster as wheelhouse
+FROM amsterdam/gob_wheelhouse:3.9-slim-bullseye as wheelhouse
 MAINTAINER datapunt@amsterdam.nl
 
 
 # Application stage.
-FROM amsterdam/gob_baseimage:3.9-buster as application
+FROM amsterdam/gob_baseimage:3.9-slim-bullseye as application
 MAINTAINER datapunt@amsterdam.nl
 # GOB base image: SQL Server driver.
 

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -57,7 +57,7 @@ no_implicit_optional = true
 
 # Getting these passing should be easy
 strict_equality = true
-strict_concatenate = true
+extra_checks = true
 
 # Strongly recommend enabling this one as soon as you can
 check_untyped_defs = true

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,11 +1,12 @@
 amsterdam-schema-tools==5.17.13
 pika==1.3.1
 
-black~=23.1.0
-coverage~=7.2.1
-flake8~=6.0.0
+# Test requirements
+black~=23.9.1
+coverage~=7.3.2
+flake8~=6.1.0
 flake8-docstrings~=1.7.0
 flake8-pyproject~=1.2.2
 isort~=5.12.0
-mypy~=1.1.1
-pytest~=7.2.2
+mypy~=1.6.0
+pytest~=7.4.2


### PR DESCRIPTION
slim-bullseye met Python 3.9.18 en updates van test packages